### PR TITLE
Fixing multi-start issue with $My being readonly

### DIFF
--- a/Log-Entry.ps1
+++ b/Log-Entry.ps1
@@ -150,7 +150,7 @@ Function End-Script([Switch]$Exit, [Int]$ErrorLevel) {
 }; Set-Alias End End-Script -Scope:Global -Description "Logs the remaining entries and errors and end the script"
 
 $Error.Clear()
-Set-Variable -Option ReadOnly My @{
+Set-Variable -Option ReadOnly -Force My @{
 	File = Get-ChildItem $MyInvocation.MyCommand.Path
 	Contents = $MyInvocation.MyCommand.ScriptContents
 	Log = @{}


### PR DESCRIPTION
If the script is included more than once in an active session, the second and subsequent inclusion fails because the script tries to set a read-only variable $My which has already been set in the first include. The solution is to just force the update and still retain read-only protect to avoid it being overwritten by some other script. This also helps with debugging sessions and multiple runs from the same session.